### PR TITLE
Allow users to set their own indentation levels. See comments.

### DIFF
--- a/ES6-Snippets/Classes/es6-class.sublime-snippet
+++ b/ES6-Snippets/Classes/es6-class.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
 class ${1:Classname} ${2:extends AnotherClass} {
-  ${3:constructor(${4:args}) {
-    ${5:// code}
-  \}}
+	${3:constructor(${4:args}) {
+		${5:// code}
+	\}}
 
-  ${6:// methods}
+	${6:// methods}
 }$7
 ]]></content>
 	<tabTrigger>class</tabTrigger>

--- a/ES6-Snippets/Generator/es6-generator.sublime-snippet
+++ b/ES6-Snippets/Generator/es6-generator.sublime-snippet
@@ -1,15 +1,15 @@
 <snippet>
 	<content><![CDATA[
 var ${1:generator} = {
-  [Symbol:iterator]: function*() {
-    ${2:var ${3:pre} = ${4:0}, ${5:cur} = ${6:1};}
-    for(;;) {
-      ${7:var ${8:temp} = ${9:pre};
-      ${9:pre} = ${10:cur};
-      ${10:cur} += ${8:temp};
-      yield ${10:cur};}
-    }
-  }
+	[Symbol:iterator]: function*() {
+		${2:var ${3:pre} = ${4:0}, ${5:cur} = ${6:1};}
+		for(;;) {
+			${7:var ${8:temp} = ${9:pre};
+			${9:pre} = ${10:cur};
+			${10:cur} += ${8:temp};
+			yield ${10:cur};}
+		}
+	}
 };
 ]]></content>
 	<tabTrigger>generator</tabTrigger>

--- a/ES6-Snippets/Let/es6-let-for.sublime-snippet
+++ b/ES6-Snippets/Let/es6-let-for.sublime-snippet
@@ -1,15 +1,15 @@
 <snippet>
 	<content><![CDATA[
 let ${1:v} = {
-  [Symbol.iterator]() {
-  	${2:let pre = ${3:0}, cur = ${4:1};}
-  	return {
-  		next() {
-  			${5:[pre, cur] = [cur, pre + cur];}
-  			${6:return ${7:\{ done: ${8:false}, value: ${9:cur}\};}}
-  		}
-  	};
-  }
+	[Symbol.iterator]() {
+		${2:let pre = ${3:0}, cur = ${4:1};}
+		return {
+			next() {
+				${5:[pre, cur] = [cur, pre + cur];}
+				${6:return ${7:\{ done: ${8:false}, value: ${9:cur}\};}}
+			}
+		};
+	}
 };$10
 ]]></content>
 	<tabTrigger>let:iterator</tabTrigger>

--- a/ES6-Snippets/Modules/es6-dynamic-import.sublime-snippet
+++ b/ES6-Snippets/Modules/es6-dynamic-import.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 System.import(${1:'my-module'})${2:.then(function(${3:m}) \{
-  $3
+	$3
 \})};
 ]]></content>
 	<tabTrigger>System.import</tabTrigger>

--- a/ES6-Snippets/Modules/es6-export-function.sublime-snippet
+++ b/ES6-Snippets/Modules/es6-export-function.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 export function ${2:name}(${3:args}) {
-  $4
+	$4
 }
 ]]></content>
 	<tabTrigger>export:function</tabTrigger>

--- a/ES6-Snippets/Modules/es6-loader-class.sublime-snippet
+++ b/ES6-Snippets/Modules/es6-loader-class.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 var ${1:loader} = new Loader({
-  ${2:global: fixup(window)}
+	${2:global: fixup(window)}
 });
 ]]></content>
 	<tabTrigger>Loader</tabTrigger>

--- a/ES6-Snippets/Object-Literal/es6-object-literal.sublime-snippet
+++ b/ES6-Snippets/Object-Literal/es6-object-literal.sublime-snippet
@@ -1,11 +1,11 @@
 <snippet>
 	<content><![CDATA[
 var ${1:obj} = {
-  __proto__: ${2:theProtoObj,}
-  ${3:handler,}
-  ${4:toString() {
-    ${5:return "object";}
-  }}
+	__proto__: ${2:theProtoObj,}
+	${3:handler,}
+	${4:toString() {
+		${5:return "object";}
+	}}
 }$6
 ]]></content>
 	<tabTrigger>object</tabTrigger>

--- a/ES6-Snippets/Promises/es6-promise.sublime-snippet
+++ b/ES6-Snippets/Promises/es6-promise.sublime-snippet
@@ -1,7 +1,7 @@
 <snippet>
 	<content><![CDATA[
 Promise((resolve, reject) => {
-  $2
+	$2
 });
 ]]></content>
 	<tabTrigger>Promise</tabTrigger>


### PR DESCRIPTION
Using tabs for indentation allows users to set their own indentation levels by using `"translate_tabs_to_spaces": true` in their settings. It currently inserts 2-space indentation into 4-space indented files.
